### PR TITLE
Fix builds on windows, and use the logger for output`

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ compileTestKotlin {
 }
 
 group 'com.xfinity'
-version '1.3.1'
+version '1.3.2'
 
 //Local publishing for development purposes
 publishing {

--- a/src/main/kotlin/com/xfinity/resourceprovider/RpCodeGenerator.kt
+++ b/src/main/kotlin/com/xfinity/resourceprovider/RpCodeGenerator.kt
@@ -25,8 +25,6 @@ class RpCodeGenerator(private val packageName: String, private val rClassInfo: R
 
     fun generateCode(directives: RpDirectives) {
         val outputDirectory = File(outputDirectoryName)
-        println("\n\n\nOutput Dir : ${outputDirectory.toString()} \n\n\n")
-
         try {
             val generateIdProvider = rClassInfo.rClassIdVars.isNotEmpty() && directives.generateIdProvider
             if (generateIdProvider) {


### PR DESCRIPTION
windows doesn't have the "bash" command readily available, so implement code-based file reading and compilation of the rclass text file.

Also, use logger instead of println for better output control