### PR TITLE
Improve performance for happy path use case by 500%

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,7 +42,7 @@ compileTestKotlin {
 }
 
 group 'com.xfinity'
-version '1.3.3'
+version '1.4.0'
 
 //Local publishing for development purposes
 publishing {

--- a/src/main/kotlin/com/xfinity/resourceprovider/ResourceProviderPlugin.kt
+++ b/src/main/kotlin/com/xfinity/resourceprovider/ResourceProviderPlugin.kt
@@ -114,14 +114,22 @@ class ResourceProviderPlugin : Plugin<Project> {
 
         val rclassTxtFile = File("${rClassDir.absolutePath}/rclass.txt")
         val outputFileWriter = rclassTxtFile.writer()
+
+        var packageResourcesPath = rClassDir.absolutePath
+        StringTokenizer(extension.packageName, ".").toList().forEach {
+            packageResourcesPath += "/$it"
+        }
+
+        val inputDir = if (extension.generateForDependencies) rClassDir else File(packageResourcesPath)
+
         project.logger.info("\nResourceProvider: Building Resource List\n")
-        rClassDir.walk().sortedBy { it.isFile }.forEach { file ->
+        inputDir.walk().sortedBy { it.isFile }.forEach { file ->
             project.logger.info(file.name)
             project.logger.info("ResourceProvider: Ingesting ${file.absolutePath}\n")
             if (file.name.endsWith(".class")) {
                 val outputStream =  ByteArrayOutputStream()
                 project.exec {
-                    it.workingDir = rClassDir
+                    it.workingDir = inputDir
                     it.commandLine = listOf("javap", "-p", file.absolutePath)
                     it.standardOutput = outputStream
                 }
@@ -163,6 +171,7 @@ open class ResourceProviderPluginExtension {
     var generateDimenProvider: Boolean = true
     var generateColorProvider: Boolean = true
     var generateIdProvider: Boolean = true
+    var generateForDependencies: Boolean = false
 }
 
 class ResourceProviderFactory {


### PR DESCRIPTION
By default, only generate resource provider APIs for resources in the app itself, not its dependencies